### PR TITLE
Add first blog post: Intro to Me

### DIFF
--- a/content/blog/001-intro-to-me.md
+++ b/content/blog/001-intro-to-me.md
@@ -1,0 +1,33 @@
+---
+title: "Intro to Me"
+date: "2026-05-18"
+excerpt: "Welcome to what's likely to be the most unkempt, chaotic, and highly inconsistent blog you'd ever dare to find on the interweb."
+tags: ["personal", "introduction"]
+status: "published"
+---
+
+# Intro to Me
+
+Welcome to what's likely to be the most unkempt, chaotic, and highly inconsistent blog you’d ever dare to find on the interweb.  What you’ll find are my rambling thoughts put to paper, all as a way to explore and get away from the meetings-on-meetings lifestyle of regular work.  All this, only to go ahead and make a Jira board for myself to track all the tasks I want to do when I'm not shepherding the Jira board of tasks I don't want to do.
+
+So, what got me to start?  To be honest, it has been bouncing around for a while in my ole’ noggin.  A stray idea here, burst of inspiration there.  Every once in a while one of those actually turned into something working, but most of the time the thoughts just got lost to the ether.  So this, this is my honest attempt to at least coalesce everything into a single space.  A way to give myself some sort of actionable task list, something that needs my follow-up no matter how jank or scatterbrained it ends up being.  
+
+I’m also not going to look the gift horse in the mouth here either, the gift that is the “free” sounding board of AI and LLM chatbots.  A way to not annoy my wife with another hairbrained scheme, a sounding board to bounce things off of.  Sure, sometimes it can be a bit overzealous in its hype train rhetoric (seriously, not every idea is good man…) but it's a good spot to bounce things around.
+
+It also lets me build simple things I've touched conceptually but never got real hands-on experience with.  For instance, this website itself, I was never a front end dev (or back end dev to be fair) but I know enough to make half-finished things, and LLMs give me the means to finish it off.  Is this the right move for a company? Hell no, there's a reason teams of people build these things.  But, for a single guy trying to cram something in on a weekend?  Abso-**fucking**-lutely.
+
+So, what are the next steps here?  Honestly, I have no clue.  I’m still just bouncing stuff around, getting stuff more like 80% done now instead of stalling out before the halfway mark.  But this post isn’t for those deep details, it's the intro, some background, and hopefully a way to get you, the reader, to stick around for more.  
+
+Frankly, I need this for a lot of reasons.  One, I just suck at transitions so maybe that will get some work.  But in reality, I want to step out of the brain-rot hell that is scrolling things like Reddit or YouTube shorts.  I like to try my best at being creative, as much as my engineer brain lets me sometimes.  And I want that to be done in a safe spot, something I can run with, and something that forces me to try and have some accountability to keep pushing even if I don’t really feel like it.  Even if this is a dead in the water, end of the line site that nobody ever visits, that's ok.  I’ll be hurt, and definitely feel a little bit bad about myself, but it's all progress, right? And sure, I’ll still kick back, play some games, watch some shows, but I want to force out some of that easy comfort and try to get a bit more done.  There’s been a serious lack of tinkering going on lately and I want to force that habit back, dredge it back up and show it off where I can, even if nothing about it is actually impressive.
+
+Alright, then let's get started on some of the things that I actually already have going on \- some of those half-baked plans and ideas that I’ll go into more detail in dedicated posts down the line.  
+
+First up, I’ve got a game project with notes going back months.  I’m calling it **AetherGears** for now, but think high fantasy steampunk with modern-ish technology, in a world where the little guy is getting crushed and watching it all get plundered of its resources by the big corpos.  That's for sure a fresh new idea that’ll sell like hotcakes, right?
+
+Next, I got a little pet project that sounds fun but surely way over my head, CookConnect.  A project built out of necessity for grad school a few months ago, but now I've got the bright idea of turning it into something more, and actually trying to keep learning from it. Crazy plan man, but maybe it’ll save me from having to go to those ridiculous cooking blog sites, having to scroll through 1000 words to learn that I needed ¼ cup of flour instead of ⅓ cup…
+
+After that, going back into my “mech e” roots is an even more insane idea of a fully custom tube-chassis race car build I’m calling **TKM001**.  It’s wild, it's insane, and man if it ever turns real you’ll probably never hear from me on the blog here.  But hopefully in the meantime I can share some pretty CAD work \- or at least *some* CAD work.
+
+And speaking of CAD work, at least my husbandly duties of “make what the wife wants” will give me some easy-win projects to share and talk about here.  This is another thing that's been off and on, some things made here and there but hopefully I can keep that to its own kind of line in the shop here, just call it  the "trying to keep my wife from being pissed at me” project, *TTKMWFBPAM* for short, obviously.
+
+But wait, there's more\! A Claude observability/metrics tracking platform, offshoot ideas from any of the other ‘main’ projects, and who knows what else I’ll come up with.  But if I can figure out how to get a couple thousand words out of it, you’ll read it here first.  So stick around, follow along, pick a project you like and ruthlessly tear me down with how terrible an idea all of it is.  I’m not going to promise weekly updates, I’m not even going to say what's coming up next, but hell isn’t that just all part of the fun and chaos of being in a forge?

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -22,7 +22,7 @@ export default async function AboutPage() {
       </p>
 
       {/* Example: Next.js Image component used directly in a page */}
-      <div className="mt-8 overflow-hidden rounded-lg">
+      {/* <div className="mt-8 overflow-hidden rounded-lg">
         <Image
           src="/images/mkv-supra.jpg"
           alt="Placeholder image — blue MkV Toyota Supra (replace with profile photo)"
@@ -34,7 +34,7 @@ export default async function AboutPage() {
         <p className="mt-2 text-center font-sans text-sm text-text-secondary">
           Placeholder — swap this out for a real profile photo or workspace shot
         </p>
-      </div>
+      </div> */}
 
       {htmlContent ? (
         <article

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,89 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  getContentBySlug,
+  getContentSlugs,
+  markdownToHtml,
+  getReadingTime,
+  type BlogFrontmatter,
+} from "@/lib/content";
+import { notFound } from "next/navigation";
+
+export const dynamicParams = false;
+
+export async function generateStaticParams() {
+  return getContentSlugs("blog").map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const data = getContentBySlug<BlogFrontmatter>("blog", slug);
+  if (!data) return { title: "Post Not Found" };
+  return {
+    title: data.frontmatter.title,
+    description: data.frontmatter.excerpt,
+  };
+}
+
+export default async function BlogPostPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const data = getContentBySlug<BlogFrontmatter>("blog", slug);
+  if (!data) notFound();
+
+  const htmlContent = await markdownToHtml(data.content);
+  const { frontmatter } = data;
+  const readingTime = getReadingTime(data.content);
+
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-16">
+      <Link
+        href="/blog"
+        className="font-sans text-sm text-purple-secondary no-underline hover:text-purple-primary"
+      >
+        &larr; Back to Blog
+      </Link>
+
+      <h1 className="mt-6 font-sans text-3xl font-bold text-purple-primary md:text-4xl">
+        {frontmatter.title}
+      </h1>
+
+      <div className="mt-4 flex items-center gap-3 font-sans text-sm text-text-secondary">
+        <time>
+          {new Date(frontmatter.date).toLocaleDateString("en-US", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+          })}
+        </time>
+        <span>&middot;</span>
+        <span>{readingTime} min read</span>
+      </div>
+
+      {frontmatter.tags.length > 0 && (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {frontmatter.tags.map((tag) => (
+            <span
+              key={tag}
+              className="rounded bg-purple-tint px-2 py-0.5 font-sans text-xs text-purple-dark"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <article
+        className="prose prose-lg mt-8 max-w-none font-serif text-text-primary"
+        dangerouslySetInnerHTML={{ __html: htmlContent }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds first blog post (`content/blog/001-intro-to-me.md`)
- Restores `blog/[slug]` dynamic route page for individual post rendering
- Updates about page content

## Test plan
- [x] CI passes (lint, typecheck, build)
- [x] Preview deployment renders the blog post at `/blog/001-intro-to-me/`
- [x] Blog list page shows the post
- [x] Home page "Recent Posts" section shows the post

🤖 Generated with [Claude Code](https://claude.com/claude-code)